### PR TITLE
add config overlay for biometric sensors

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -353,4 +353,13 @@
 
     <!-- True if the firmware supports p2p MAC randomization -->
     <bool name="config_wifi_p2p_mac_randomization_supported">true</bool>
+
+    <!-- List of biometric sensors on the device, in decreasing strength. Consumed by AuthService
+         when registering authenticators with BiometricService. Format must be ID:Modality:Strength,
+         where: IDs are unique per device, Modality as defined in BiometricAuthenticator.java,
+         and Strength as defined in Authenticators.java -->
+    <string-array name="config_biometric_sensors" translatable="false" >
+        <!-- ID0:Fingerprint:Strong -->
+        <item>0:2:15</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
Related to https://github.com/GrapheneOS/os_issue_tracker/issues/325 and https://github.com/GrapheneOS/os_issue_tracker/issues/326, but similar changes still need to be done for the other devices.

0:2:15 is the same value found in the product overlays for the sargo and bonito factory images. The linked issues are no longer present on sargo after applying this overlay.